### PR TITLE
use primer3 to calculate primer design Tms instead of pydna default function

### DIFF
--- a/src/opencloning/endpoints/primer_design.py
+++ b/src/opencloning/endpoints/primer_design.py
@@ -209,8 +209,8 @@ async def primer_design_ebic(
 # @router.post('/primer_design/gateway_attB', response_model=PrimerDesignResponse)
 # async def primer_design_gateway_attB(
 #     template: PrimerDesignQuery,
-#     left_site: str = Query(..., description='The left attB site to recombine.', regex=r'^attB[1-5]$'),
-#     right_site: str = Query(..., description='The right attB site to recombine.', regex=r'^attB[1-5]$'),
+#     left_site: str = Query(..., description='The left attB site to recombine.', pattern=r'^attB[1-5]$'),
+#     right_site: str = Query(..., description='The right attB site to recombine.', pattern=r'^attB[1-5]$'),
 #     spacers: list[str] | None = Body(None, description='Spacers to add between the attB site and the primer.'),
 #     filler_bases: str = Query(
 #         'GGGG',
@@ -276,7 +276,7 @@ class PrimerDetailsResponse(BaseModel):
 
 @router.get('/primer_details', response_model=PrimerDetailsResponse)
 async def primer_details(
-    sequence: str = Query(..., description='Primer sequence', regex=r'^[ACGTacgt]+$'),
+    sequence: str = Query(..., description='Primer sequence', pattern=r'^[ACGTacgt]+$'),
 ):
     """Get information about a primer"""
     sequence = sequence.upper()
@@ -299,8 +299,8 @@ async def primer_details(
 
 @router.get('/primer_heterodimer', response_model=ThermodynamicResult | None)
 async def primer_heterodimer(
-    sequence1: str = Query(..., description='First primer sequence', regex=r'^[ACGTacgt]+$'),
-    sequence2: str = Query(..., description='Second primer sequence', regex=r'^[ACGTacgt]+$'),
+    sequence1: str = Query(..., description='First primer sequence', pattern=r'^[ACGTacgt]+$'),
+    sequence2: str = Query(..., description='Second primer sequence', pattern=r'^[ACGTacgt]+$'),
 ):
     """Get information about a primer pair"""
 

--- a/src/opencloning/primer_design.py
+++ b/src/opencloning/primer_design.py
@@ -7,6 +7,12 @@ from .pydantic_models import PrimerModel
 from Bio.Seq import reverse_complement
 from Bio.Restriction.Restriction import RestrictionType
 from Bio.Data.IUPACData import ambiguous_dna_values as _ambiguous_dna_values
+from primer3.bindings import calc_tm as _calc_tm
+
+
+def primer3_calc_tm(seq: str) -> float:
+    return _calc_tm(seq.upper())
+
 
 ambiguous_dna_values = _ambiguous_dna_values.copy()
 # Remove acgt
@@ -27,7 +33,9 @@ def homologous_recombination_primers(
 ) -> tuple[str, str]:
 
     fragment2amplify = pcr_loc.extract(pcr_seq)
-    amplicon = primer_design(fragment2amplify, limit=minimal_hybridization_length, target_tm=target_tm)
+    amplicon = primer_design(
+        fragment2amplify, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=primer3_calc_tm
+    )
 
     if insert_forward:
         fwd_primer, rvs_primer = amplicon.primers()
@@ -79,7 +87,8 @@ def gibson_assembly_primers(
 ) -> list[PrimerModel]:
 
     initial_amplicons = [
-        primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm) for template in templates
+        primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=primer3_calc_tm)
+        for template in templates
     ]
 
     for i, amplicon in enumerate(initial_amplicons):
@@ -145,7 +154,9 @@ def simple_pair_primers(
     if len(spacers) != 2:
         raise ValueError("The 'spacers' list must contain exactly two elements.")
 
-    amplicon = primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm)
+    amplicon = primer_design(
+        template, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=primer3_calc_tm
+    )
     fwd_primer, rvs_primer = amplicon.primers()
 
     if fwd_primer is None or rvs_primer is None:

--- a/src/opencloning/primer_design.py
+++ b/src/opencloning/primer_design.py
@@ -8,6 +8,7 @@ from Bio.Seq import reverse_complement
 from Bio.Restriction.Restriction import RestrictionType
 from Bio.Data.IUPACData import ambiguous_dna_values as _ambiguous_dna_values
 from primer3.bindings import calc_tm as _calc_tm
+from typing import Callable
 
 
 def primer3_calc_tm(seq: str) -> float:
@@ -30,11 +31,12 @@ def homologous_recombination_primers(
     insert_forward: bool,
     target_tm: float,
     spacers: list[str] | None = None,
+    tm_func: Callable[[str], float] = primer3_calc_tm,
 ) -> tuple[str, str]:
 
     fragment2amplify = pcr_loc.extract(pcr_seq)
     amplicon = primer_design(
-        fragment2amplify, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=primer3_calc_tm
+        fragment2amplify, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=tm_func
     )
 
     if insert_forward:
@@ -84,10 +86,11 @@ def gibson_assembly_primers(
     target_tm: float,
     circular: bool,
     spacers: list[str] | None = None,
+    tm_func: Callable[[str], float] = primer3_calc_tm,
 ) -> list[PrimerModel]:
 
     initial_amplicons = [
-        primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=primer3_calc_tm)
+        primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=tm_func)
         for template in templates
     ]
 
@@ -142,6 +145,7 @@ def simple_pair_primers(
     spacers: list[str] | None = None,
     left_enzyme_inverted: bool = False,
     right_enzyme_inverted: bool = False,
+    tm_func: Callable[[str], float] = primer3_calc_tm,
 ) -> tuple[PrimerModel, PrimerModel]:
     """
     Design primers to amplify a DNA fragment, if left_enzyme or right_enzyme are set, the primers will be designed
@@ -154,9 +158,7 @@ def simple_pair_primers(
     if len(spacers) != 2:
         raise ValueError("The 'spacers' list must contain exactly two elements.")
 
-    amplicon = primer_design(
-        template, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=primer3_calc_tm
-    )
+    amplicon = primer_design(template, limit=minimal_hybridization_length, target_tm=target_tm, tm_func=tm_func)
     fwd_primer, rvs_primer = amplicon.primers()
 
     if fwd_primer is None or rvs_primer is None:

--- a/tests/test_endpoints_primer_design.py
+++ b/tests/test_endpoints_primer_design.py
@@ -26,9 +26,9 @@ client = TestClient(_main.app)
 class PrimerDesignTest(unittest.TestCase):
 
     def test_homologous_recombination(self):
-        pcr_seq = format_sequence_genbank(Dseqrecord('GAAATGGAACAGTGCCAGAAATTTTT'))
+        pcr_seq = format_sequence_genbank(Dseqrecord('AATGATGGATGACATTCAAAGCACTGATTCTATTGCTGAAAAAGATAAT'))
         pcr_seq.id = 1
-        pcr_loc = PydanticSimpleLocation(start=1, end=23)
+        pcr_loc = PydanticSimpleLocation(start=4, end=44)
         hr_seq = format_sequence_genbank(Dseqrecord('AAACGTTT'))
         hr_seq.id = 2
         hr_loc_replace = PydanticSimpleLocation(start=3, end=5)
@@ -59,8 +59,8 @@ class PrimerDesignTest(unittest.TestCase):
         payload = response.json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(payload['primers'][0]['sequence'], 'aaaAAATGGAACAG')
-        self.assertEqual(payload['primers'][1]['sequence'], 'aaaAATTTCTGGC')
+        self.assertEqual(payload['primers'][0]['sequence'], 'aaaATGGATGACATT')
+        self.assertEqual(payload['primers'][1]['sequence'], 'aaaCTTTTTCAGCAA')
 
         # Raise valuerror
         params['homology_length'] = 10
@@ -71,14 +71,14 @@ class PrimerDesignTest(unittest.TestCase):
 
         # Test an insertion with spacers and reversed insert
         params['homology_length'] = 3
-        data['homologous_recombination_target']['forward_orientation'] = False
+        data['pcr_template']['forward_orientation'] = False
         data['homologous_recombination_target']['location'] = PydanticSimpleLocation(start=3, end=3).model_dump()
         data['spacers'] = ['attt', 'cggg']
         response = client.post('/primer_design/homologous_recombination', json=data, params=params)
         self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(payload['primers'][0]['sequence'], 'aaaatttAAATGGAACAG')
-        self.assertEqual(payload['primers'][1]['sequence'], 'acgcccgAATTTCTGGC')
+        self.assertEqual(payload['primers'][0]['sequence'], 'aaaatttCTTTTTCAGCAA')
+        self.assertEqual(payload['primers'][1]['sequence'], 'acgcccgATGGATGACATT')
 
         # Raise error if the number of spacers is incorrect
         data['spacers'] = ['attt', 'cggg', 'tttt']

--- a/tests/test_primer_design.py
+++ b/tests/test_primer_design.py
@@ -21,9 +21,9 @@ class TestHomologousRecombinationPrimers(TestCase):
         Test the homologous_recombination_primers function.
         """
 
-        #                      >>>>>>>>>>> <<<<<<<<<<
-        pcr_seq = Dseqrecord('GAAATGGAACAGTGCCAGAAATTTTT')
-        pcr_loc = SimpleLocation(1, 23)
+        #
+        pcr_seq = Dseqrecord('AATGATGGATGACATTCAAAGCACTGATTCTATTGCTGAAAAAGATAAT')
+        pcr_loc = SimpleLocation(4, 44)
         hr_seq = Dseqrecord('AAACGTTT')
         homology_length = 3
         minimal_hybridization_length = 10
@@ -42,7 +42,7 @@ class TestHomologousRecombinationPrimers(TestCase):
             insert_forward,
             target_tm,
         )
-        self.assertEqual(primers, ('aaaAAATGGAACAG', 'aaaAATTTCTGGC'))
+        self.assertEqual(primers, ('aaaATGGATGACATT', 'aaaCTTTTTCAGCAA'))
 
         # An insertion
         hr_loc_insert = SimpleLocation(3, 3)
@@ -56,7 +56,7 @@ class TestHomologousRecombinationPrimers(TestCase):
             insert_forward,
             target_tm,
         )
-        self.assertEqual(primers, ('aaaAAATGGAACAG', 'acgAATTTCTGGC'))
+        self.assertEqual(primers, ('aaaATGGATGACATT', 'acgCTTTTTCAGCAA'))
 
         # Same, circular and we loop
         pcr_seq = pcr_seq.looped()
@@ -73,16 +73,16 @@ class TestHomologousRecombinationPrimers(TestCase):
             hr_loc_replace = hr_shifted.features[0].location
             hr_loc_insert = hr_shifted.features[1].location
             solutions = (
-                ('aaaAAATGGAACAG', 'aaaAATTTCTGGC'),
-                ('aaaAAATGGAACAG', 'acgAATTTCTGGC'),
+                ('aaaATGGATGACATT', 'aaaCTTTTTCAGCAA'),
+                ('aaaATGGATGACATT', 'acgCTTTTTCAGCAA'),
             )
             for shift_hr in range(len(hr_seq)):
                 hr_shifted = hr_seq.shifted(shift_hr)
                 hr_loc_replace = hr_shifted.features[0].location
                 hr_loc_insert = hr_shifted.features[1].location
                 solutions = (
-                    ('aaaAAATGGAACAG', 'aaaAATTTCTGGC'),
-                    ('aaaAAATGGAACAG', 'acgAATTTCTGGC'),
+                    ('aaaATGGATGACATT', 'aaaCTTTTTCAGCAA'),
+                    ('aaaATGGATGACATT', 'acgCTTTTTCAGCAA'),
                 )
                 for hr_loc, solution in zip([hr_loc_replace, hr_loc_insert], solutions):
                     for insert_forward in (True, False):
@@ -116,8 +116,7 @@ class TestHomologousRecombinationPrimers(TestCase):
             target_tm,
             spacers,
         )
-
-        solution = ('aaaatttAAATGGAACAG', 'acgcccgAATTTCTGGC')
+        solution = ('aaaatttATGGATGACATT', 'acgcccgCTTTTTCAGCAA')
         self.assertEqual(primers, solution)
 
         # The spacer is defined with respect to the locus, not the insert
@@ -135,13 +134,13 @@ class TestHomologousRecombinationPrimers(TestCase):
             spacers,
         )
 
-        solution = ('aaaatttAATTTCTGGC', 'acgcccgAAATGGAACAG')
+        solution = ('aaaatttCTTTTTCAGCAA', 'acgcccgATGGATGACATT')
         self.assertEqual(primers, solution)
 
     def test_clashing_homology(self):
 
-        pcr_seq = Dseqrecord('GAAATGGAACAGTGCCAGAAATTTTT')
-        pcr_loc = SimpleLocation(1, 23)
+        pcr_seq = Dseqrecord('AATGATGGATGACATTCAAAGCACTGATTCTATTGCTGAAAAAGATAAT')
+        pcr_loc = SimpleLocation(4, 44)
         hr_seq = Dseqrecord('AAACGTTT')
         homology_length = 5
         minimal_hybridization_length = 10
@@ -214,8 +213,8 @@ class TestHomologousRecombinationPrimers(TestCase):
             self.assertEqual(str(e), 'Homology arms overlap.')
 
     def test_errors(self):
-        pcr_seq = Dseqrecord('GAAATGGAACAGTGCCAGAAATTTTT')
-        pcr_loc = SimpleLocation(1, 23)
+        pcr_seq = Dseqrecord('AATGATGGATGACATTCAAAGCACTGATTCTATTGCTGAAAAAGATAAT')
+        pcr_loc = SimpleLocation(4, 44)
         hr_seq = Dseqrecord('AAACGTTT')
         homology_length = 3
         minimal_hybridization_length = 10
@@ -519,7 +518,7 @@ class TestSimplePairPrimers(TestCase):
         """
         Test the restriction_enzyme_primers function without restriction enzymes.
         """
-        template = Dseqrecord('ATGCAAACAGTGAACAGATGGAGACAATAATGATGGATGAC')
+        template = Dseqrecord('ATGCAAACAGTGAACAGATACAGATGGAGACAATGGAGACAATAATGATGGATGAC')
         minimal_hybridization_length = 10
         target_tm = 55
         filler_bases = 'GC'


### PR DESCRIPTION
Previously, I was using [pydna's default melting temperature calculator](https://github.com/pydna-group/pydna/blob/master/src/pydna/tm.py) to calculate the Tms for the primer design.

I have now switched to use primer3, which gives lower values. I don't have a good sense of what of the two is better, but I made this choice because:

- Primer3 is a known library, so people know what to expect from it.
- I am using primer3 to calculate other primer properties in the frontend https://github.com/manulera/OpenCloning_frontend/issues/429

If you are using scripts, you can set which tm function you want to use when calling functions in [primer_design](https://github.com/manulera/OpenCloning_backend/blob/master/src/opencloning/primer_design.py), by passing a `Callable[[str], float]` as `tm_func`.
