### PR TITLE
Reduce image size and packages numbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ FROM python:3.11-slim-bookworm
 # directly output things to stdout/stderr, without buffering
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && apt-get install -y mafft libgomp1
+RUN apt-get update && apt-get install --no-install-recommends -y mafft libgomp1
 
 # create a user to run the app
 RUN useradd -ms /bin/bash backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ FROM python:3.11-slim-bookworm
 # directly output things to stdout/stderr, without buffering
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && apt-get install --no-install-recommends -y mafft libgomp1
+RUN apt-get update && apt-get install --no-install-recommends -y mafft libgomp1 && rm -rf /var/lib/apt/lists/*
 
 # create a user to run the app
 RUN useradd -ms /bin/bash backend


### PR DESCRIPTION
[apt: do not install recommended packages](https://github.com/manulera/OpenCloning_backend/commit/c8c8ac8078e40a8bc370d3e278ae807684dc4fac)

this will install ruby and other things we don't need (see
https://packages.debian.org/sid/mafft).

Image size goes from 534 Mb to 480 Mb.

Vulnerabilities count goes from 136 to 102.

[apt: remove apt cache, save 20 mb more](https://github.com/manulera/OpenCloning_backend/commit/a53df4e993887e6239af77830c718e510072494f)