### PR TITLE
Handle errors in read_dseqrecord_from_json

### DIFF
--- a/src/opencloning/endpoints/external_import.py
+++ b/src/opencloning/endpoints/external_import.py
@@ -38,6 +38,7 @@ from ..dna_functions import (
     custom_file_parser,
     get_sequence_from_euroscarf_url,
     get_seva_plasmid,
+    read_dsrecord_from_json,
 )
 from .. import request_examples
 from .. import ncbi_requests
@@ -196,6 +197,10 @@ async def read_from_file(
 
     if len(warning_messages) > 0:
         response.headers['x-warning'] = '; '.join(warning_messages)
+
+    # Validate that the sequences are in a valid genbank format
+    for seq in out_sequences:
+        read_dsrecord_from_json(seq)
 
     return {'sequences': out_sequences, 'sources': out_sources}
 

--- a/tests/test_dna_functions.py
+++ b/tests/test_dna_functions.py
@@ -4,6 +4,7 @@ import os
 import respx
 from pydna.dseq import Dseq
 from Bio.Seq import reverse_complement
+from opencloning_linkml.datamodel import TextFileSequence, SequenceFileFormat
 
 from opencloning.dna_functions import (
     custom_file_parser,
@@ -12,6 +13,7 @@ from opencloning.dna_functions import (
     get_sequence_from_euroscarf_url,
     oligonucleotide_hybridization_overhangs,
     get_sequences_from_file_url,
+    read_dsrecord_from_json,
 )
 
 test_files = os.path.join(os.path.dirname(__file__), 'test_files')
@@ -122,3 +124,18 @@ class GetSequencesFromFileUrlTest(unittest.IsolatedAsyncioTestCase):
             await get_sequences_from_file_url('https://assets.opencloning.org/annotated-igem-distribution/blah.gb')
         self.assertEqual(e.exception.status_code, 404)
         self.assertIn('file requested from url not found', e.exception.detail)
+
+
+class ReadDsrecordFromJsonTest(unittest.TestCase):
+    def test_read_dsrecord_from_json_error(self):
+        seq = TextFileSequence(
+            id=1,
+            file_content='',
+            sequence_file_format=SequenceFileFormat('genbank'),
+            overhang_crick_3prime=0,
+            overhang_watson_3prime=0,
+        )
+        with self.assertRaises(HTTPException) as e:
+            read_dsrecord_from_json(seq)
+        self.assertEqual(e.exception.status_code, 422)
+        self.assertIn('The file for sequence with id 1 is not in a valid genbank format: ', e.exception.detail)


### PR DESCRIPTION
related to https://github.com/biopython/biopython/issues/5116

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use custom GenBank parser with clear 422 errors and validate uploaded sequences post-parse; add tests for invalid inputs.
> 
> - **Backend**
>   - `src/opencloning/dna_functions.py`:
>     - Replace `pydna_parse` with `custom_file_parser` in `read_dsrecord_from_json`, raising `HTTPException(422)` on invalid GenBank content.
>     - Preserve overhang handling; no change to output structure.
> - **API**
>   - `src/opencloning/endpoints/external_import.py`:
>     - After parsing uploads, validate each `TextFileSequence` by calling `read_dsrecord_from_json` before returning.
> - **Tests**
>   - `tests/test_dna_functions.py`:
>     - Add `ReadDsrecordFromJsonTest` to assert 422 on invalid GenBank input.
>     - Update imports to include `read_dsrecord_from_json` and datamodel types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3428d8225e706d135e0300b1e61ae758161cbbc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->