### PR TITLE
Fix bug in get_info_from_annotation

### DIFF
--- a/src/opencloning/endpoints/external_import.py
+++ b/src/opencloning/endpoints/external_import.py
@@ -219,6 +219,9 @@ def handle_repository_errors(exception: Exception, repository_name: str) -> None
     elif isinstance(exception, ConnectError):
         raise HTTPException(504, f'Unable to connect to {repository_name}: {exception}')
     else:  # pragma: no cover
+        import traceback
+
+        traceback.print_exc()
         raise HTTPException(500, f'Unexpected error: {exception}')
 
 

--- a/src/opencloning/ncbi_requests.py
+++ b/src/opencloning/ncbi_requests.py
@@ -136,9 +136,9 @@ def get_info_from_annotation(annotation: dict) -> dict:
     start = int(annotation['genomic_regions'][0]['gene_range']['range'][0]['begin'])
     end = int(annotation['genomic_regions'][0]['gene_range']['range'][0]['end'])
     strand = 1 if annotation['genomic_regions'][0]['gene_range']['range'][0]['orientation'] == 'plus' else -1
-    gene_id = int(annotation['gene_id'])
     sequence_accession = annotation['genomic_regions'][0]['gene_range']['accession_version']
     locus_tag = annotation['locus_tag'] if 'locus_tag' in annotation else None
+    gene_id = int(annotation['gene_id']) if 'gene_id' in annotation else None
     try:
         assembly_accession = annotation['annotations'][0]['assembly_accession']
     except KeyError:

--- a/tests/test_ncbi_requests.py
+++ b/tests/test_ncbi_requests.py
@@ -161,3 +161,12 @@ class NcbiAsyncRequestsTest(unittest.IsolatedAsyncioTestCase):
             ncbi_requests.get_info_from_annotation(example_annotation)
         )
         self.assertEqual(assembly_accession, None)
+
+        # If gene id or locus tag is not present, it should be None
+        del example_annotation['gene_id']
+        del example_annotation['locus_tag']
+        start, end, strand, gene_id, sequence_accession, locus_tag, assembly_accession = (
+            ncbi_requests.get_info_from_annotation(example_annotation)
+        )
+        self.assertEqual(gene_id, None)
+        self.assertEqual(locus_tag, None)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `get_info_from_annotation` robust to missing `gene_id` (and test it), and print tracebacks for unexpected errors in external import handler.
> 
> - **NCBI requests**:
>   - Update `get_info_from_annotation` to return `None` when `gene_id` is absent (keeps existing optional `locus_tag`).
>   - Tests: extend `tests/test_ncbi_requests.py` to assert `gene_id`/`locus_tag` become `None` when missing.
> - **External import**:
>   - Enhance `handle_repository_errors` in `src/opencloning/endpoints/external_import.py` to print a traceback for unexpected errors before raising `HTTPException(500)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7481e75b7887651f425708db4e5945799ec10b38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->